### PR TITLE
add support for chunking plaintext

### DIFF
--- a/zuul_alpha/defaults.py
+++ b/zuul_alpha/defaults.py
@@ -5,5 +5,6 @@ APP_ROOT = os.getenv('APP_ROOT', os.getcwd())
 DEFAULT_ENV = 'development'
 ENV_TAGS = [DEFAULT_ENV, 'staging', 'production']
 DEFAULT_RSA_KEY_SIZE = 2048
+CHUNK_SIZE = 214
 DEFAULT_CIPHERTEXT_EXT = '.enc'
 ZUUL_DATA_DIR = os.path.join(APP_ROOT, 'zuul_data')


### PR DESCRIPTION
Plaintext payload cannot be larger than the byte value of the key.
(2048 / 8) - pkcs1_padding = 214